### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/src/AmberEggApi.Domain.Tests/AmberEggApi.Domain.Tests.csproj
+++ b/src/AmberEggApi.Domain.Tests/AmberEggApi.Domain.Tests.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.4" />
-    <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -23,14 +23,14 @@
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit.Console" Version="3.12.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.12.0" />
     <PackageReference Include="NUnit.Runners" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Api.Common.Repository.EFCore.Tests/Api.Common.Repository.EFCore.Tests.csproj
+++ b/src/Api.Common.Repository.EFCore.Tests/Api.Common.Repository.EFCore.Tests.csproj
@@ -12,9 +12,9 @@
     </PackageReference>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit.Console" Version="3.12.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.12.0" />
     <PackageReference Include="NUnit.Runners" Version="3.12.0" />


### PR DESCRIPTION
Hi@diegodocs, I found an issue in the AmberEggApi.Domain.Tests.csproj:

Packages coverlet.msbuild v3.0.3, Microsoft.EntityFrameworkCore.InMemory v5.0.3, Microsoft.NET.Test.Sdk v16.9.1, NUnit v3.13.1 and NUnit3TestAdapter v3.17.0 transitively introduce 173 dependencies into AmberEggApi’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/AmberEggApi.html)), while coverlet.msbuild v3.1.0, Microsoft.EntityFrameworkCore.InMemory v5.0.4, Microsoft.NET.Test.Sdk v16.9.4, NUnit v3.13.2 and NUnit3TestAdapter v4.0.0 can only introduce 134 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/AmberEggApi_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose